### PR TITLE
Changing MessageId into From (Firebase bug)

### DIFF
--- a/DataPushAndroid/.idea/compiler.xml
+++ b/DataPushAndroid/.idea/compiler.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <option name="BUILD_PROCESS_HEAP_SIZE" value="1024" />
-    <option name="BUILD_PROCESS_ADDITIONAL_VM_OPTIONS" value="-Xmx512m" />
+    <option name="DEFAULT_COMPILER" value="Javac" />
     <resourceExtensions />
     <wildcardResourcePatterns>
       <entry name="!?*.java" />
@@ -13,7 +12,6 @@
       <entry name="!?*.flex" />
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
-      <entry name="!?*.aj" />
     </wildcardResourcePatterns>
     <annotationProcessing>
       <profile default="true" name="Default" enabled="false">

--- a/DataPushAndroid/.idea/dictionaries/Engenharia.xml
+++ b/DataPushAndroid/.idea/dictionaries/Engenharia.xml
@@ -1,0 +1,3 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="Engenharia" />
+</component>

--- a/DataPushAndroid/.idea/gradle.xml
+++ b/DataPushAndroid/.idea/gradle.xml
@@ -5,7 +5,7 @@
       <GradleProjectSettings>
         <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="C:\Users\André Pereira\Desktop\android-studio\gradle\gradle-2.14.1" />
+        <option name="gradleHome" value="C:\Users\Engenharia\Desktop\android-studio\gradle\gradle-2.14.1" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/DataPushAndroid/.idea/misc.xml
+++ b/DataPushAndroid/.idea/misc.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="AndroidDexCompilerConfiguration">
-    <option name="VM_OPTIONS" value="-Xmx512m" />
-    <option name="MAX_HEAP_SIZE" value="1024" />
-    <option name="PROGUARD_VM_OPTIONS" value="-Xmx256m" />
-  </component>
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
@@ -32,6 +27,25 @@
       </value>
     </option>
   </component>
+  <component name="ProjectInspectionProfilesVisibleTreeState">
+    <entry key="Project Default">
+      <profile-state>
+        <expanded-state>
+          <State>
+            <id />
+          </State>
+          <State>
+            <id>Spelling</id>
+          </State>
+        </expanded-state>
+        <selected-state>
+          <State>
+            <id>Spelling</id>
+          </State>
+        </selected-state>
+      </profile-state>
+    </entry>
+  </component>
   <component name="ProjectLevelVcsManager" settingsEditedManually="false">
     <OptionsSetting value="true" id="Add" />
     <OptionsSetting value="true" id="Remove" />
@@ -42,10 +56,26 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">
     <option name="id" value="Android" />
+  </component>
+  <component name="masterDetails">
+    <states>
+      <state key="ProjectJDKs.UI">
+        <settings>
+          <last-edited>1.7</last-edited>
+          <splitter-proportions>
+            <option name="proportions">
+              <list>
+                <option value="0.2" />
+              </list>
+            </option>
+          </splitter-proportions>
+        </settings>
+      </state>
+    </states>
   </component>
 </project>

--- a/DataPushAndroid/app/build.gradle
+++ b/DataPushAndroid/app/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     })
     compile 'com.android.support:appcompat-v7:22.2.1'
     compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha5'
-    compile 'com.google.firebase:firebase-messaging:9.0.0'
+    compile 'com.google.firebase:firebase-messaging:9.4.0'
     compile 'se.simbio.encryption:library:1.2.0'
     testCompile 'junit:junit:4.12'
 }

--- a/DataPushAndroid/app/src/main/java/andre/com/datapushandroid/MainActivity.java
+++ b/DataPushAndroid/app/src/main/java/andre/com/datapushandroid/MainActivity.java
@@ -122,7 +122,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
 
         Toast.makeText(MainActivity.this,
-                "Push Id: " + String.valueOf(restoredId)
+                "Push From: " + String.valueOf(restoredId)
                 + "\n\nMensagem: " + String.valueOf(response),
                 Toast.LENGTH_LONG).show();
     }

--- a/DataPushAndroid/app/src/main/java/andre/com/datapushandroid/services/FCMService.java
+++ b/DataPushAndroid/app/src/main/java/andre/com/datapushandroid/services/FCMService.java
@@ -15,7 +15,6 @@
  */
 
 package andre.com.datapushandroid.services;
-
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -44,7 +43,7 @@ public class FCMService extends FirebaseMessagingService implements EncryptionRe
     private static final String TAG = "FCMService";
     public final static String MY_ACTION = "SAVE_PUSH_NOTIFICATION";
 
-    String push_id = "";
+    private String push_id = "";
 
     /**
      * Called when message is received.
@@ -65,10 +64,22 @@ public class FCMService extends FirebaseMessagingService implements EncryptionRe
         // [END_EXCLUDE]
 
         // TODO(developer): Handle FCM messages here.
-        // Not getting messages here? See why this may be: https://goo.gl/39bRNJ
+
+        // Getting MessageId will return null for a majority of devices (not all of them).
+        // This is a bug in Firebase and it will be fixed on 9.4+
+        // You can check it at
+        //
+        // http://stackoverflow.com/questions/38007894/fcm-android-null-message-id
+        //
+
+        // push_id = remoteMessage.getMessageId();
+
+        // I'm now changing the id to the sender of this message which also has an unique ID.
+
+        push_id = remoteMessage.getFrom();
         Log.d(TAG, "From: " + remoteMessage.getFrom());
 
-        push_id = remoteMessage.getMessageId();
+        //Log.d(TAG, "Id: " + remoteMessage.getMessageId());
 
         Intent intent = new Intent();
         intent.setAction(MY_ACTION);

--- a/DataPushAndroid/app/src/main/java/andre/com/datapushandroid/services/FCM_InstanceIdService.java
+++ b/DataPushAndroid/app/src/main/java/andre/com/datapushandroid/services/FCM_InstanceIdService.java
@@ -41,19 +41,6 @@ public class FCM_InstanceIdService extends FirebaseInstanceIdService {
         // If you want to send messages to this application instance or
         // manage this apps subscriptions on the server side, send the
         // Instance ID token to your app server.
-        sendRegistrationToServer(refreshedToken);
     }
     // [END refresh_token]
-
-    /**
-     * Persist token to third-party servers.
-     *
-     * Modify this method to associate the user's FCM InstanceID token with any server-side account
-     * maintained by your application.
-     *
-     * @param token The new token.
-     */
-    private void sendRegistrationToServer(String token) {
-        // TODO: Implement this method to send token to your app server.
-    }
 }


### PR DESCRIPTION
Getting MessageId will return null for a majority of devices (not all of them).
This is a bug in Firebase and it will be fixed on 9.4+
You can check it at http://stackoverflow.com/questions/38007894/fcm-android-null-message-id
